### PR TITLE
Función create_app descomentada. Fixes #1

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -19,7 +19,6 @@ load_dotenv()
 db = SQLAlchemy()
 migrate = Migrate()
 
-'''
 def create_app(config_name='development'):
     app = Flask(__name__)
 
@@ -65,6 +64,5 @@ def create_app(config_name='development'):
         }
 
     return app
-'''
 
 app = create_app()


### PR DESCRIPTION
Se solucionó el error descomentando el bloque de texto que definía la función create_app en app/\_\_init__.py